### PR TITLE
Propose That Developer Removes `node_modules` before npm installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Vagrant setup for developing Ghost
 - Login to the VM with `vagrant ssh`
 - Change to the Ghost source directory: `cd code/Ghost`
 - Install git submodules: `git submodule update --recurse`
-- Install dependencies: `npm install`
+- Install dependencies: `rm -rf node_modules/ && npm install`
 - Build Admin styles: `grunt init`
 - Run the Ghost App: `node app.js`
 - Validate code: `grunt validate`


### PR DESCRIPTION
Proposing that the developer removes any existing trace of `node_modules` that are inherited from the host OS.

This small change should make it harder for people to stumble on errors across building in different OSs, namely SQLite.
