### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Vagrant setup for developing Ghost
 
 ## Instructions
 
-- Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Vagrant 1.2.2](http://downloads.vagrantup.com/tags/v1.2.2)
+- Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads), [Vagrant 1.2.2](http://downloads.vagrantup.com/tags/v1.2.2) and an [NFS Server](http://en.wikipedia.org/wiki/Network_File_System) (nfs-kernel-server on Ubuntu)
 - Clone this repo
 - Edit the `Vagrantfile` in the root
     - Change your `GhostSourcePath` to match your environment


### PR DESCRIPTION
Adding info about installing NFSd on Linux.

nfsd is not pre-installed on Ubuntu/Debian and `vagrant up` is throwing an error since it can't mount the Ghost directory on the host.
