### PR TITLE
Init scripts

### DIFF
--- a/modules/ghost/files/config/app.conf
+++ b/modules/ghost/files/config/app.conf
@@ -1,0 +1,27 @@
+description "ghost app server"
+author      "ghost.org"
+
+env PROGRAM_NAME="ghost"
+env FULL_PATH="/home/vagrant/code/Ghost"
+env FILE_NAME="index.js"
+env NODE_PATH="/home/vagrant/nvm/v0.10.5/bin/node"
+
+start on startup
+stop on shutdown
+
+script
+
+    echo $$ > /var/run/$PROGRAM_NAME.pid
+    cd $FULL_PATH
+    exec $NODE_PATH $FULL_PATH/$FILE_NAME >> $FULL_PATH/node_app.log 2>&1
+end script
+
+pre-start script
+    # Date format same as (new Date()).toISOString() for consistency
+    echo "[`date -u +%Y-%m-%dT%T.%3NZ`] (sys) Starting" >> $FULL_PATH/node_app.log
+end script
+
+pre-stop script
+    rm /var/run/$PROGRAM_NAME.pid
+    echo "[`date -u +%Y-%m-%dT%T.%3NZ`] (sys) Stopping" >> $FULL_PATH/node_app.log
+end script

--- a/modules/ghost/manifests/init.pp
+++ b/modules/ghost/manifests/init.pp
@@ -11,6 +11,10 @@ class ghost($node_version = "v0.10.5") {
         require => [Class["essentials"]]
     }
 
+    class { upstart:
+        require => [Class["essentials"]]
+    }
+
     # Install and setup phantomjs and casperjs
     class { casperjs:
         require => [Class["essentials"]]
@@ -45,9 +49,22 @@ class ghost($node_version = "v0.10.5") {
     }
 
     # Examples of installing packages from a package.json if we need to.
-    #exec { "npm-install-packages":
-    #  cwd => "/home/vagrant/",
-    #  command => "npm install .",
-    #  require => Exec['install-node'],
-    #}
+    exec { "npm-install-packages":
+      cwd => "/home/vagrant/code/Ghost",
+      command => "npm install",
+      require => Exec['install-node'],
+    }
+
+    exec { "git submodule update":
+      cwd     => "/home/vagrant/code/Ghost",
+      command => "git submodule update --init",
+      require => Class["essentials"]
+    }
+
+    exec { "grunt init":
+      cwd => "/home/vagrant/code/Ghost",
+      command => "grunt init",
+      require => Exec["npm-install-packages"]
+    }
+
 }

--- a/modules/ghost/manifests/upstart.pp
+++ b/modules/ghost/manifests/upstart.pp
@@ -1,0 +1,15 @@
+class upstart {
+
+    file { "app-conf":
+        ensure  => file,
+        path => "/etc/init/app.conf",
+        source => "puppet:///modules/ghost/config/app.conf"
+    }
+
+    service { 'app':
+        ensure => running,
+        provider => 'upstart',
+        require => File['app-conf'],
+    }
+
+}


### PR DESCRIPTION
Addresses #29

Upstart is used to daemonize the node.js server. Meaning as soon as the user does a `vagrant up` the server will be running and waiting for them at the IP specified in the Vagranfile.

In addition, the `git submodule update --init`, `npm install`, and `grunt init` is performed every time the VM is booted, to ensure the node server will startup smoothly.
