### PR TITLE
Remove text/html from nginx gzip config

### DIFF
--- a/modules/ghost/files/config/nginx.conf
+++ b/modules/ghost/files/config/nginx.conf
@@ -8,7 +8,7 @@ server {
   gzip_vary on;
   gzip_min_length  1000;
   gzip_proxied any;
-  gzip_types text/plain text/html text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
   gzip_buffers 16 8k;
 
   keepalive_timeout 5;


### PR DESCRIPTION
Stops the `[warn] duplicate MIME type "text/html"` error

"text/html" is always compressed, so you don't need to specify it explicitly :+1:
