### PR TITLE
Update node to 0.10.26 and fix permissions

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,5 +1,5 @@
 
-$node_version = "v0.10.5"
+$node_version = "v0.10.26"
 
 file { '/etc/motd':
 	content => "

--- a/modules/ghost/manifests/init.pp
+++ b/modules/ghost/manifests/init.pp
@@ -1,5 +1,5 @@
 
-class ghost($node_version = "v0.10.5") {
+class ghost($node_version = "v0.10.26") {
     # Add some default path values
     Exec { path => ['/usr/local/bin','/usr/local/sbin','/usr/bin/','/usr/sbin','/bin','/sbin', "/home/vagrant/nvm/${node_version}/bin"], }
 
@@ -18,6 +18,7 @@ class ghost($node_version = "v0.10.5") {
     }
 
     class { upstart:
+        node_version => $node_version,
         require => [Class["essentials"]]
     }
 

--- a/modules/ghost/manifests/nvm.pp
+++ b/modules/ghost/manifests/nvm.pp
@@ -19,6 +19,16 @@ class nvm ($node_version) {
     timeout => 0,
   }
 
+  # Ensure proper permissions for nvm (and node in general)
+  file { "set-node-permissions":
+    path => "/home/vagrant/nvm/${node_version}", 
+    ensure => "directory",
+    recurse => true,
+    owner  => "vagrant",
+    group  => "vagrant",
+    require => [Exec['install-node']]
+  }
+
   exec { "clone-nvm":
     command => "git clone git://github.com/creationix/nvm.git /home/vagrant/nvm",
     user => "vagrant",

--- a/modules/ghost/manifests/upstart.pp
+++ b/modules/ghost/manifests/upstart.pp
@@ -1,9 +1,9 @@
-class upstart {
+class upstart ($node_version) {
 
     file { "app-conf":
         ensure  => file,
         path => "/etc/init/app.conf",
-        source => "puppet:///modules/ghost/config/app.conf"
+        content => template("ghost/config/app.conf")
     }
 
     service { 'app':

--- a/modules/ghost/templates/config/app.conf
+++ b/modules/ghost/templates/config/app.conf
@@ -4,7 +4,7 @@ author      "ghost.org"
 env PROGRAM_NAME="ghost"
 env FULL_PATH="/home/vagrant/code/Ghost"
 env FILE_NAME="index.js"
-env NODE_PATH="/home/vagrant/nvm/v0.10.5/bin/node"
+env NODE_PATH="/home/vagrant/nvm/<%= node_version %>/bin/node"
 
 start on startup
 stop on shutdown


### PR DESCRIPTION
Should close #36
- Update default version to 0.10.26 in manifests where hard coded
- Change upstart config to template with node_version passed in
- Update recursively the owner on the nvm folder to ensure permissions
