### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Vagrant setup for developing [Ghost](https://ghost.org)
 - Clone the Ghost master repo with `git clone git://github.com/Tryghost/Ghost.git` (_case matters!_)
 - Enter `echo '192.168.33.10 local.tryghost.org' | sudo tee -a /etc/hosts > /dev/null` to configure URL forwarding.
 - Enter `vagrant up` to create your new Vagrant box and `vagrant ssh` to log in.
-- After logging into your box enter `cd /code/Ghost` and install Ghost by running `npm install` and `grunt init`.
+- After logging into your box enter `cd ~/code/Ghost` and install Ghost by running `npm install` and `grunt init`.
 - Enter `npm start`
 
 ## Stopping and Starting Ghost


### PR DESCRIPTION
Minor typo in README.md, User should get into ~/code/Ghost not /code/Ghost