### PR TITLE
Remove PhantomJS tar from repo

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -5,5 +5,6 @@ mod 'puppetlabs-mysql', '~> 2.3.0'
 mod 'puppetlabs-stdlib', '~> 4.4.0'
 mod 'puppetlabs-concat', '~> 1.2.0'
 mod 'puppetlabs-postgresql', '~> 4.3.0'
+mod 'puppet-archive', '~> 0.4.4'
 mod 'ghost-ghost',
   :path => 'site-modules/ghost'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,12 +1,16 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
+    puppet-archive (0.4.4)
+      puppetlabs-pe_gem (>= 0.0.1)
+      puppetlabs-stdlib (>= 2.2.1)
     puppetlabs-apt (1.8.0)
       puppetlabs-stdlib (>= 2.2.1)
     puppetlabs-concat (1.2.4)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     puppetlabs-mysql (2.3.1)
       puppetlabs-stdlib (>= 3.2.0)
+    puppetlabs-pe_gem (0.1.2)
     puppetlabs-postgresql (4.3.0)
       puppetlabs-apt (< 2.0.0, >= 1.8.0)
       puppetlabs-concat (< 2.0.0, >= 1.1.0)
@@ -21,6 +25,7 @@ PATH
 
 DEPENDENCIES
   ghost-ghost (>= 0)
+  puppet-archive (~> 0.4.4)
   puppetlabs-concat (~> 1.2.0)
   puppetlabs-mysql (~> 2.3.0)
   puppetlabs-postgresql (~> 4.3.0)

--- a/site-modules/ghost/manifests/casperjs.pp
+++ b/site-modules/ghost/manifests/casperjs.pp
@@ -1,24 +1,20 @@
 #  Install and symlink casperjs and phantomjs
 
 class casperjs {
-
-    file { "phantomjs-src":
-      path => "/home/vagrant/software/phantomjs-1.9.8-linux-x86_64.tar.bz2",
-      source => "puppet:///modules/ghost/software/phantomjs-1.9.8-linux-x86_64.tar.bz2",
-    }
-
-    exec { "extract-phantomjs":
-        cwd => "/home/vagrant/software",
-        command => "/bin/tar xvjf phantomjs-1.9.8-linux-x86_64.tar.bz2",
-        creates => "/home/vagrant/software/phantomjs-1.9.8-linux-x86_64",
-        require => [File["phantomjs-src"]]
+    archive { "phantomjs":
+        source => "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2",
+        path => "/tmp/phantomjs-1.9.8-linux-x86_64.tar.bz2",
+        extract => true,
+        extract_path => "/home/vagrant/software",
+        checksum => "d29487b2701bcbe3c0a52bc176247ceda4d09d2d",
+        checksum_type => "sha1",
+        creates => "/home/vagrant/software/phantomjs-1.9.8-linux-x86_64"
     }
 
     exec { "link-phantomjs":
-        cwd => "/home/vagrant/software/phantomjs-1.9.8-linux-x86_64",
         command => "/bin/ln -sf /home/vagrant/software/phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs",
         creates => "/usr/local/bin/phantomjs",
-        require => [Exec["extract-phantomjs"]]
+        require => [Archive["phantomjs"]]
     }
 
     exec { "git-casperjs":


### PR DESCRIPTION
This PR removes the PhantomJS tar from the repo and instead downloads it when provisioning. This reduces the size of the repo and the amount of time it takes to clone the repo.