### PR TITLE
Readme update for slightly clearer instructions and resolving #87 and #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ You will need the following applications to setup the Ghost development environm
 - [Git](https://git-scm.com/downloads)
 
 Linux users will also need `nfs-common` and `nfs-kernel-server`
+
 Windows users should install Vagrant to a directory with no spaces in the path
+
 ```bash
 sudo apt-get install nfs-common nfs-kernel-sever
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You will need the following applications to setup the Ghost development environm
 - [Git](https://git-scm.com/downloads)
 
 Linux users will also need `nfs-common` and `nfs-kernel-server`
-
+Windows users should install Vagrant to a directory with no spaces in the path
 ```bash
 sudo apt-get install nfs-common nfs-kernel-sever
 ```
@@ -25,7 +25,7 @@ git clone git://github.com/TryGhost/Ghost-Vagrant.git
 cd Ghost-Vagrant
 ```
 
-You will now need a copy of Ghost itself:
+You will now need a copy of Ghost itself, cloned into your new local Ghost-Vagrant repo:
 
 ```bash
 git clone git://github.com/Tryghost/Ghost.git

--- a/README.md
+++ b/README.md
@@ -12,24 +12,24 @@ You will need the following applications to setup the Ghost development environm
 
 Linux users will also need `nfs-common` and `nfs-kernel-server`
 
-Windows users should install Vagrant to a directory with no spaces in the path
-
 ```bash
 sudo apt-get install nfs-common nfs-kernel-sever
 ```
 
+Windows users should install Vagrant to a directory with no spaces in the path
+
 ## Setup
 
-To get started with the Ghost development environment, you will first need to clone this repo and navigate into it:
+To get started with the Ghost development environment, you will first need to clone this repo:
 
 ```bash
 git clone git://github.com/TryGhost/Ghost-Vagrant.git
-cd Ghost-Vagrant
 ```
 
-You will now need a copy of Ghost itself, cloned into your new local Ghost-Vagrant repo:
+Clone the Ghost repo into your new local Ghost-Vagrant repo:
 
 ```bash
+cd Ghost-Vagrant
 git clone git://github.com/Tryghost/Ghost.git
 ```
 


### PR DESCRIPTION
Readme update to make setup instructions clearer

Closes #87 and #88
- Specify that Vagrant should not have a space in the installation path on Windows
- Explain that Ghost repo clone should be within the Ghost-Vagrant repo clone
